### PR TITLE
Edit the regex pattern to find exactly key

### DIFF
--- a/src/Console/EnvSetCommand.php
+++ b/src/Console/EnvSetCommand.php
@@ -63,7 +63,7 @@ class EnvSetCommand extends Command
     public function setVariable($name, $value)
     {
         $replaced = preg_replace(
-            "/$name=.*/",
+            $this->keyMatchingPattern($name),
             "$name=$value",
             file_get_contents($envFilePath = $this->laravel->environmentFilePath())
         );
@@ -107,11 +107,22 @@ class EnvSetCommand extends Command
     public function env($key)
     {
         $isMatch = preg_match(
-            "/$key=(.*)/",
+            $this->keyMatchingPattern($key),
             file_get_contents($this->laravel->environmentFilePath()),
             $matches
         );
 
         return $isMatch ? $matches[1] : null;
+    }
+
+    /**
+     * Get a regex pattern that will match passed key.
+     *
+     * @param  string  $key
+     * @return string
+     */
+    public function keyMatchingPattern($key)
+    {
+        return "/^$key=(.*)$/m";
     }
 }


### PR DESCRIPTION
## About

- The old regex pattern: `/$key=(.*)/`. It'll match all of the key has last string is $key.
- e.g: If the value of $key is **T**. We have `/T=(.*)/` and it will match:
```
MAIL_HOST=test
MAIL_PORT=test
T=test
```

- Now, it's fixed.
## References

- N/A