### PR TITLE
[Console] Maintain app:name command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "illuminate/contracts": "~5.5",
         "illuminate/database": "~5.5",
         "illuminate/http": "~5.5",
-        "illuminate/support": "~5.5"
+        "illuminate/support": "~5.5",
+        "illuminate/filesystem": "~5.5"
     },
     "replace": {
         "sepiphy/laravel-console": "self.version",

--- a/src/Console/AppNamespaceCommand.php
+++ b/src/Console/AppNamespaceCommand.php
@@ -1,0 +1,293 @@
+<?php
+
+/*
+ * This file is part of the Sepiphy package.
+ *
+ * (c) Nguyễn Xuân Quỳnh <nguyenxuanquynh2210vghy@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sepiphy\Laravel\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Composer;
+use Symfony\Component\Finder\Finder;
+use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Console\Input\InputArgument;
+
+class AppNamespaceCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'app:namespace {namespace : The app namespace}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Set the application namespace';
+
+    /**
+     * The Composer class instance.
+     *
+     * @var \Illuminate\Support\Composer
+     */
+    protected $composer;
+
+    /**
+     * The filesystem instance.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $files;
+
+    /**
+     * Current root application namespace.
+     *
+     * @var string
+     */
+    protected $currentRoot;
+
+    /**
+     * Create a new key generator command.
+     *
+     * @param  \Illuminate\Support\Composer  $composer
+     * @param  \Illuminate\Filesystem\Filesystem  $files
+     * @return void
+     */
+    public function __construct(Composer $composer, Filesystem $files)
+    {
+        parent::__construct();
+
+        $this->files = $files;
+        $this->composer = $composer;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->currentRoot = trim($this->laravel->getNamespace(), '\\');
+
+        $this->setAppDirectoryNamespace();
+        $this->setBootstrapNamespaces();
+        $this->setConfigNamespaces();
+        $this->setComposerNamespace();
+        $this->setDatabaseFactoryNamespaces();
+
+        $this->info('Application namespace set!');
+
+        $this->composer->dumpAutoloads();
+
+        $this->call('optimize:clear');
+    }
+
+    /**
+     * Set the namespace on the files in the app directory.
+     *
+     * @return void
+     */
+    protected function setAppDirectoryNamespace()
+    {
+        $files = Finder::create()
+                            ->in($this->laravel['path'])
+                            ->contains($this->currentRoot)
+                            ->name('*.php');
+
+        foreach ($files as $file) {
+            $this->replaceNamespace($file->getRealPath());
+        }
+    }
+
+    /**
+     * Replace the App namespace at the given path.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    protected function replaceNamespace($path)
+    {
+        $search = [
+            'namespace '.$this->currentRoot.';',
+            $this->currentRoot.'\\',
+        ];
+
+        $replace = [
+            'namespace '.$this->argument('namespace').';',
+            $this->argument('namespace').'\\',
+        ];
+
+        $this->replaceIn($path, $search, $replace);
+    }
+
+    /**
+     * Set the bootstrap namespaces.
+     *
+     * @return void
+     */
+    protected function setBootstrapNamespaces()
+    {
+        $search = [
+            $this->currentRoot.'\\Http',
+            $this->currentRoot.'\\Console',
+            $this->currentRoot.'\\Exceptions',
+        ];
+
+        $replace = [
+            $this->argument('namespace').'\\Http',
+            $this->argument('namespace').'\\Console',
+            $this->argument('namespace').'\\Exceptions',
+        ];
+
+        $this->replaceIn($this->getBootstrapPath(), $search, $replace);
+    }
+
+    /**
+     * Set the namespace in the appropriate configuration files.
+     *
+     * @return void
+     */
+    protected function setConfigNamespaces()
+    {
+        $this->setAppConfigNamespaces();
+        $this->setAuthConfigNamespace();
+        $this->setServicesConfigNamespace();
+    }
+
+    /**
+     * Set the application provider namespaces.
+     *
+     * @return void
+     */
+    protected function setAppConfigNamespaces()
+    {
+        $search = [
+            $this->currentRoot.'\\Providers',
+            $this->currentRoot.'\\Http\\Controllers\\',
+        ];
+
+        $replace = [
+            $this->argument('namespace').'\\Providers',
+            $this->argument('namespace').'\\Http\\Controllers\\',
+        ];
+
+        $this->replaceIn($this->getConfigPath('app'), $search, $replace);
+    }
+
+    /**
+     * Set the authentication User namespace.
+     *
+     * @return void
+     */
+    protected function setAuthConfigNamespace()
+    {
+        $this->replaceIn(
+            $this->getConfigPath('auth'),
+            $this->currentRoot.'\\User',
+            $this->argument('namespace').'\\User'
+        );
+    }
+
+    /**
+     * Set the services User namespace.
+     *
+     * @return void
+     */
+    protected function setServicesConfigNamespace()
+    {
+        $this->replaceIn(
+            $this->getConfigPath('services'),
+            $this->currentRoot.'\\User',
+            $this->argument('namespace').'\\User'
+        );
+    }
+
+    /**
+     * Set the PSR-4 namespace in the Composer file.
+     *
+     * @return void
+     */
+    protected function setComposerNamespace()
+    {
+        $this->replaceIn(
+            $this->getComposerPath(),
+            str_replace('\\', '\\\\', $this->currentRoot).'\\\\',
+            str_replace('\\', '\\\\', $this->argument('namespace')).'\\\\'
+        );
+    }
+
+    /**
+     * Set the namespace in database factory files.
+     *
+     * @return void
+     */
+    protected function setDatabaseFactoryNamespaces()
+    {
+        $files = Finder::create()
+                            ->in($this->laravel->databasePath('factories'))
+                            ->contains($this->currentRoot)
+                            ->name('*.php');
+
+        foreach ($files as $file) {
+            $this->replaceIn(
+                $file->getRealPath(),
+                $this->currentRoot, $this->argument('namespace')
+            );
+        }
+    }
+
+    /**
+     * Replace the given string in the given file.
+     *
+     * @param  string  $path
+     * @param  string|array  $search
+     * @param  string|array  $replace
+     * @return void
+     */
+    protected function replaceIn($path, $search, $replace)
+    {
+        if ($this->files->exists($path)) {
+            $this->files->put($path, str_replace($search, $replace, $this->files->get($path)));
+        }
+    }
+
+    /**
+     * Get the path to the bootstrap/app.php file.
+     *
+     * @return string
+     */
+    protected function getBootstrapPath()
+    {
+        return $this->laravel->bootstrapPath().'/app.php';
+    }
+
+    /**
+     * Get the path to the Composer.json file.
+     *
+     * @return string
+     */
+    protected function getComposerPath()
+    {
+        return $this->laravel->basePath('composer.json');
+    }
+
+    /**
+     * Get the path to the given configuration file.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getConfigPath($name)
+    {
+        return $this->laravel['path.config'].'/'.$name.'.php';
+    }
+}

--- a/src/Console/ConsoleServiceProvider.php
+++ b/src/Console/ConsoleServiceProvider.php
@@ -32,6 +32,7 @@ class ConsoleServiceProvider extends ServiceProvider
         'TraitMakeCommand' => 'command.trait.make',
         'SearchCommand' => 'command.search',
         'EnvSetCommand' => 'command.env.set',
+        'AppNamespaceCommand' => 'command.app.namespace',
     ];
 
     /**
@@ -118,6 +119,19 @@ class ConsoleServiceProvider extends ServiceProvider
     {
         $this->app->singleton($name, function ($app) {
             return new EnvSetCommand;
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    protected function registerAppNamespaceCommand($name)
+    {
+        $this->app->singleton($name, function ($app) {
+            return new AppNamespaceCommand($app['composer'], $app['files']);
         });
     }
 }

--- a/src/Console/composer.json
+++ b/src/Console/composer.json
@@ -20,7 +20,9 @@
         }
     ],
     "require": {
-        "illuminate/console": "~5.5"
+        "illuminate/console": "~5.5",
+        "illuminate/support": "~5.5",
+        "illuminate/filesystem": "~5.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## About

- **app:name** command was removed from laravel master branch. We want to maintain this command with the new name `app:namespace`.

## References

- N/A

